### PR TITLE
Add brokerage to holdings

### DIFF
--- a/lib/belay_brokerage/holding.ex
+++ b/lib/belay_brokerage/holding.ex
@@ -5,6 +5,7 @@ defmodule BelayBrokerage.Holding do
     field(:investor_id, :string, primary_key: true)
     field(:sym, :string, primary_key: true)
     field(:qty, :decimal)
+    field(:brokerage, :string)
 
     timestamps()
   end
@@ -13,5 +14,5 @@ defmodule BelayBrokerage.Holding do
     change(holding, qty: new_qty)
   end
 
-  def_new(required: ~w(sym qty investor_id)a)
+  def_new(required: ~w(sym qty investor_id brokerage)a)
 end

--- a/priv/repo/tenant_migrations/20240116185212_add_brokerage_to_holdings.exs
+++ b/priv/repo/tenant_migrations/20240116185212_add_brokerage_to_holdings.exs
@@ -1,0 +1,9 @@
+defmodule BelayBrokerage.Repo.Migrations.AddBrokerageToHoldings do
+  use Ecto.Migration
+
+  def change do
+    alter table(:holdings) do
+      add :brokerage, :string
+    end
+  end
+end

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -67,7 +67,8 @@ defmodule BelayBrokerageTest do
       investor_id = "id"
       qty = Decimal.from_float(1.0)
 
-      assert {:ok, %Holding{}} = BelayBrokerage.holding_transaction(@default_tenant, investor_id, "AAPL", qty)
+      assert {:ok, %Holding{}} =
+               BelayBrokerage.holding_transaction(@default_tenant, investor_id, "AAPL", qty, "brokerage")
 
       assert [holding] = BelayBrokerage.get_holdings(@default_tenant, investor_id)
       assert holding.sym == "AAPL"
@@ -80,7 +81,7 @@ defmodule BelayBrokerageTest do
       delta_qty = Decimal.from_float(1.0)
 
       assert {:ok, %Holding{}} =
-               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, delta_qty)
+               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, delta_qty, "brokerage")
 
       assert [holding] = BelayBrokerage.get_holdings(@default_tenant, investor_id)
       assert holding.qty == Decimal.add(existing_qty, delta_qty)
@@ -91,7 +92,7 @@ defmodule BelayBrokerageTest do
       delta_qty = Decimal.from_float(-1.0)
 
       assert {:ok, %Holding{}} =
-               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, delta_qty)
+               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, delta_qty, "brokerage")
 
       assert BelayBrokerage.get_holdings(@default_tenant, investor_id) == []
     end
@@ -104,7 +105,7 @@ defmodule BelayBrokerageTest do
       qty = Decimal.from_float(1.0)
 
       # When qty is positive
-      assert {:ok, %Holding{}} = BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, qty)
+      assert {:ok, %Holding{}} = BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, qty, "brokerage")
 
       # type is buy
       assert_receive {:handle_message,
@@ -119,7 +120,7 @@ defmodule BelayBrokerageTest do
 
       # When qty is negative
       assert {:ok, %Holding{}} =
-               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, Decimal.negate(qty))
+               BelayBrokerage.holding_transaction(@default_tenant, investor_id, sym, Decimal.negate(qty), "brokerage")
 
       # type is sell
       assert_receive {:handle_message,
@@ -137,7 +138,7 @@ defmodule BelayBrokerageTest do
       start_supervised!({TestTransactionHandler, self()})
 
       assert {:error, %Ecto.Changeset{errors: [qty: {"is invalid", _}]}} =
-               BelayBrokerage.holding_transaction(@default_tenant, "id", "AAPL", "not a decimal")
+               BelayBrokerage.holding_transaction(@default_tenant, "id", "AAPL", "not a decimal", "brokerage")
 
       refute_receive {:handle_message, _}
     end


### PR DESCRIPTION
Aashay wants to be able to track where a solo user owns their holding when they insure it. To do this, Lee and I just added a brokerage field to holdings. When a holding is saved, it's saved with a brokerage. Since only one policy can be bought per symbol on the belay API, it should be totally fine to just add it only when a new holding is created.