### PR TITLE
Add account_id needed for transfers

### DIFF
--- a/lib/belay_brokerage/investor.ex
+++ b/lib/belay_brokerage/investor.ex
@@ -13,6 +13,7 @@ defmodule BelayBrokerage.Investor do
     field(:email, :string)
     field(:phone, :string)
     field(:access_token, :string)
+    field(:account_id, :string)
 
     timestamps()
   end

--- a/priv/repo/tenant_migrations/20240119231241_add_account_id.exs
+++ b/priv/repo/tenant_migrations/20240119231241_add_account_id.exs
@@ -1,0 +1,9 @@
+defmodule BelayBrokerage.Repo.Migrations.AddAccountId do
+  use Ecto.Migration
+
+  def change do
+    alter table(:investors) do
+      add :account_id, :string
+    end
+  end
+end

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -38,7 +38,7 @@ defmodule BelayBrokerageTest do
 
       assert {:ok, %Investor{}} = BelayBrokerage.upsert_investor(@default_tenant, investor)
 
-      investor = investor |> Map.put(:access_token, "access_token")
+      investor = investor |> Map.merge(%{access_token: "access_token", account_id: "account_id"})
       assert {:ok, %Investor{} = received_investor} = BelayBrokerage.upsert_investor(@default_tenant, investor)
 
       assert investor.first_name == received_investor.first_name
@@ -51,6 +51,7 @@ defmodule BelayBrokerageTest do
       assert investor.email == received_investor.email
       assert investor.phone == received_investor.phone
       assert investor.access_token == "access_token"
+      assert investor.account_id == "account_id"
     end
 
     test "returns changeset on error" do


### PR DESCRIPTION
Everything needs access_token, but we need the account_id for which we're to interact.