### PR TITLE
Fix transaction qty for claims

### DIFF
--- a/lib/belay_brokerage/transactions.ex
+++ b/lib/belay_brokerage/transactions.ex
@@ -39,7 +39,7 @@ defmodule BelayBrokerage.Transactions do
     typed_embedded_schema do
       field(:investor_id, :string)
       field(:sym, :string)
-      field(:qty, :decimal)
+      field(:delta_qty, :decimal)
       field(:type, Ecto.Enum, values: [:buy, :sell])
     end
 

--- a/lib/belay_brokerage/transactions.ex
+++ b/lib/belay_brokerage/transactions.ex
@@ -40,7 +40,6 @@ defmodule BelayBrokerage.Transactions do
       field(:investor_id, :string)
       field(:sym, :string)
       field(:delta_qty, :decimal)
-      field(:type, Ecto.Enum, values: [:buy, :sell])
     end
 
     def_new(required: :all)

--- a/lib/belay_brokerage/transactions.ex
+++ b/lib/belay_brokerage/transactions.ex
@@ -47,14 +47,14 @@ defmodule BelayBrokerage.Transactions do
   end
 
   @spec publish_transaction(String.t(), String.t(), Decimal.t()) :: :ok | {:error, any()}
-  def publish_transaction(investor_id, sym, qty) do
-    transaction_type = if Decimal.gt?(qty, Decimal.new(0)), do: :buy, else: :sell
+  def publish_transaction(investor_id, sym, qty_delta) do
+    transaction_type = if Decimal.gt?(qty_delta, Decimal.new(0)), do: :buy, else: :sell
 
     Rabbit.Producer.publish(
       BelayBrokerage.Transactions.Producer,
       @belaybrokerage_exchange,
       @belaybrokerage_transactions_queue,
-      Message.new!(%{investor_id: investor_id, sym: sym, qty: qty, type: transaction_type}),
+      Message.new!(%{investor_id: investor_id, sym: sym, qty: Decimal.abs(qty_delta), type: transaction_type}),
       content_type: "application/json"
     )
   end

--- a/lib/belay_brokerage/transactions.ex
+++ b/lib/belay_brokerage/transactions.ex
@@ -48,13 +48,11 @@ defmodule BelayBrokerage.Transactions do
 
   @spec publish_transaction(String.t(), String.t(), Decimal.t()) :: :ok | {:error, any()}
   def publish_transaction(investor_id, sym, qty_delta) do
-    transaction_type = if Decimal.gt?(qty_delta, Decimal.new(0)), do: :buy, else: :sell
-
     Rabbit.Producer.publish(
       BelayBrokerage.Transactions.Producer,
       @belaybrokerage_exchange,
       @belaybrokerage_transactions_queue,
-      Message.new!(%{investor_id: investor_id, sym: sym, qty: Decimal.abs(qty_delta), type: transaction_type}),
+      Message.new!(%{investor_id: investor_id, sym: sym, qty: qty_delta}),
       content_type: "application/json"
     )
   end

--- a/lib/belay_brokerage/transactions.ex
+++ b/lib/belay_brokerage/transactions.ex
@@ -47,12 +47,12 @@ defmodule BelayBrokerage.Transactions do
   end
 
   @spec publish_transaction(String.t(), String.t(), Decimal.t()) :: :ok | {:error, any()}
-  def publish_transaction(investor_id, sym, qty_delta) do
+  def publish_transaction(investor_id, sym, delta_qty) do
     Rabbit.Producer.publish(
       BelayBrokerage.Transactions.Producer,
       @belaybrokerage_exchange,
       @belaybrokerage_transactions_queue,
-      Message.new!(%{investor_id: investor_id, sym: sym, qty: qty_delta}),
+      Message.new!(%{investor_id: investor_id, sym: sym, delta_qty: delta_qty}),
       content_type: "application/json"
     )
   end

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -151,7 +151,7 @@ defmodule BelayBrokerageTest do
                         decoded_payload: %{
                           "investor_id" => ^investor_id,
                           "sym" => ^sym,
-                          "qty" => "-1.0",
+                          "qty" => "1.0",
                           "type" => "sell"
                         }
                       }}

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -136,8 +136,7 @@ defmodule BelayBrokerageTest do
                         decoded_payload: %{
                           "investor_id" => ^investor_id,
                           "sym" => ^sym,
-                          "qty" => "1.0",
-                          "type" => "buy"
+                          "delta_qty" => "1.0",
                         }
                       }}
 
@@ -151,8 +150,7 @@ defmodule BelayBrokerageTest do
                         decoded_payload: %{
                           "investor_id" => ^investor_id,
                           "sym" => ^sym,
-                          "qty" => "1.0",
-                          "type" => "sell"
+                          "delta_qty" => "-1.0",
                         }
                       }}
     end

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -136,7 +136,7 @@ defmodule BelayBrokerageTest do
                         decoded_payload: %{
                           "investor_id" => ^investor_id,
                           "sym" => ^sym,
-                          "delta_qty" => "1.0",
+                          "delta_qty" => "1.0"
                         }
                       }}
 
@@ -150,7 +150,7 @@ defmodule BelayBrokerageTest do
                         decoded_payload: %{
                           "investor_id" => ^investor_id,
                           "sym" => ^sym,
-                          "delta_qty" => "-1.0",
+                          "delta_qty" => "-1.0"
                         }
                       }}
     end


### PR DESCRIPTION
This PR:
- [x] Changes the qty being sent to belay to be the absolute value

## The issue

I could claim a policy as solo, and it would increase the qty of my policy. This was because we were sending an event off to the transaction listener with a delta qty, and it would just directly create the asset sell and asset buy messages. The problem with that is that asset sell and asset buy aren't meant to take a qty delta, just the unsigned qty of the transaction, thus incrementing my policy because `qty_sold` was negative.

## Is this solution confusing

I had a talk with Kevin about this solution and we wanted to make sure this wasn't confusing to the rest of the team. Basically, we were unsure where to make the change. The belay brokerage prefers to have a delta qty so it can easily think about what types of transactions to fire and how to manipulate the investor holdings accordingly, but on the belay side, we want the absolute qty for the asset messages. We weren't sure if it changing the belay brokerage or the transaction listener was the way to go.