### PR TITLE
Feature/add plaid item id support

### DIFF
--- a/lib/belay_brokerage.ex
+++ b/lib/belay_brokerage.ex
@@ -13,6 +13,7 @@ defmodule BelayBrokerage do
   require Logger
 
   @type investor :: %{
+          required(:id) => String.t(),
           required(:first_name) => String.t(),
           required(:last_name) => String.t(),
           required(:address_1) => String.t(),
@@ -23,8 +24,8 @@ defmodule BelayBrokerage do
           required(:email) => String.t(),
           required(:phone) => String.t(),
           required(:access_token) => String.t(),
-          required(:id) => String.t(),
-          required(:account_id) => String.t()
+          required(:account_id) => String.t(),
+          required(:item_id) => String.t()
         }
 
   @spec all_investors(String.t()) :: [Investor.t()]
@@ -51,6 +52,13 @@ defmodule BelayBrokerage do
   @spec get_investor(String.t(), String.t()) :: Investor.t() | nil
   def get_investor(partner_id, investor_id) do
     Repo.get(Investor, investor_id, prefix: partner_id)
+  end
+
+  @spec get_investor_by_item_id(String.t(), String.t()) :: Investor.t() | nil
+  def get_investor_by_item_id(partner_id, item_id) do
+    query = from(i in Investor, where: i.item_id == ^item_id)
+
+    Repo.one(query, prefix: partner_id)
   end
 
   @spec holding_transaction(String.t(), String.t(), String.t(), Decimal.t(), String.t()) ::

--- a/lib/belay_brokerage/investor.ex
+++ b/lib/belay_brokerage/investor.ex
@@ -14,6 +14,7 @@ defmodule BelayBrokerage.Investor do
     field(:phone, :string)
     field(:access_token, :string)
     field(:account_id, :string)
+    field(:item_id, :string)
 
     timestamps()
   end

--- a/lib/belay_brokerage/investor.ex
+++ b/lib/belay_brokerage/investor.ex
@@ -19,7 +19,7 @@ defmodule BelayBrokerage.Investor do
   end
 
   def_new(
-    required: ~w(first_name last_name address_1 city region postal_code email phone)a,
+    required: ~w(first_name last_name address_1 city region postal_code email phone access_token account_id item_id)a,
     default: [id: {Ecto.UUID, :generate, []}]
   )
 end

--- a/priv/repo/tenant_migrations/20240206205433_add_item_id_to_investor.exs
+++ b/priv/repo/tenant_migrations/20240206205433_add_item_id_to_investor.exs
@@ -1,0 +1,9 @@
+defmodule BelayBrokerage.Repo.Migrations.AddItemIdToInvestor do
+  use Ecto.Migration
+
+  def change do
+    alter table(:investors) do
+      add :item_id, :string
+    end
+  end
+end

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -79,6 +79,18 @@ defmodule BelayBrokerageTest do
     end
   end
 
+  describe "get_investor_by_item_id/2" do
+    test "retrieves inserted investor" do
+      investor = insert!(:investor)
+
+      assert BelayBrokerage.get_investor_by_item_id(@default_tenant, investor.item_id) == investor
+    end
+
+    test "returns nil when no investor exists" do
+      assert BelayBrokerage.get_investor_by_item_id(@default_tenant, "some item_id") == nil
+    end
+  end
+
   describe "get_holdings/2" do
     test "retrieves all holdings" do
       investor_id = "investor_id"

--- a/test/belay_brokerage_test.exs
+++ b/test/belay_brokerage_test.exs
@@ -16,7 +16,7 @@ defmodule BelayBrokerageTest do
   end
 
   describe "create_investor/2" do
-    test "when investor has no access_token, it's still inserted (it's optional)" do
+    test "when investor has all data, it's inserted" do
       investor = build(:investor)
 
       assert {:ok, %Investor{} = received_investor} = BelayBrokerage.create_investor(@default_tenant, investor)
@@ -30,7 +30,9 @@ defmodule BelayBrokerageTest do
       assert investor.postal_code == received_investor.postal_code
       assert investor.email == received_investor.email
       assert investor.phone == received_investor.phone
-      assert investor.access_token == nil
+      assert investor.access_token == received_investor.access_token
+      assert investor.account_id == received_investor.account_id
+      assert investor.item_id == received_investor.item_id
     end
 
     test "returns changeset on error" do

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -16,7 +16,9 @@ defmodule BelayBrokerage.Factory do
       region: "PA",
       postal_code: "19103",
       email: "johndoe@email.com",
-      phone: "123-123-1234"
+      phone: "123-123-1234",
+      access_token: "access_token",
+      account_id: "account_id"
     }
   end
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,8 @@ defmodule BelayBrokerage.Factory do
       email: "johndoe@email.com",
       phone: "123-123-1234",
       access_token: "access_token",
-      account_id: "account_id"
+      account_id: "account_id",
+      item_id: "item_id"
     }
   end
 


### PR DESCRIPTION
- Add `item_id` to investor table to be able to correlate a webhook update to an investor
- Fix some fields marked as optional actually being required fields 